### PR TITLE
Remove extra term in main protocol, equation 6

### DIFF
--- a/PLONK-with-lookups.tex
+++ b/PLONK-with-lookups.tex
@@ -608,8 +608,8 @@ $\sone (\hgen^i) = s_i$ for $i\in [n+1]$; and $\stwo(\hgen ^i)= s_{n+i}$ for eac
  \begin{enumerate}
   \item $L_1(\X)(Z(\X)-1)= 0$.
   \item 
-  \[(\X-\hgen^{n+1})Z(\X)(1+\beta)\cdot (\gamma + f(\X))(\gamma(1+\beta)+ t(\X)+\beta t(\hgen \cdot \X) )\]
-  \[= (\X-\hgen^{n+1}) Z(\hgen\cdot \X)(\gamma(1+\beta)+ \sone(\X)+\beta \sone(\hgen \cdot \X))(\gamma(1+\beta)+ \stwo(\X)+\beta \stwo(\hgen \cdot \X))\]
+  \[Z(\X)(1+\beta)\cdot (\gamma + f(\X))(\gamma(1+\beta)+ t(\X)+\beta t(\hgen \cdot \X) )\]
+  \[= Z(\hgen\cdot \X)(\gamma(1+\beta)+ \sone(\X)+\beta \sone(\hgen \cdot \X))(\gamma(1+\beta)+ \stwo(\X)+\beta \stwo(\hgen \cdot \X))\]
   \item\label{check:consist} $L_{n+1}(\X)(\sone(\X)-\stwo(\hgen \cdot \X))= 0$.
 %   \item $Z(\cosetgen\cdot  \X)(\gamma(1+\beta)+ t(\X)+\beta t(\X\cdot \hgen) )=Z(\cosetgen\hgen \cdot  \X)(\gamma(1+\beta)+ s(\cosetgen \X)+\beta s(\cosetgen \X\cdot \hgen) )$.
   \item $L_{n+1}(\X)(Z(\X)-1)= 0$.


### PR DESCRIPTION
In Main protocol, line 6, the term (x - g^{n + 1}) is in both sides of this expression. 

Removing it made it easier for me to parse the eq. 